### PR TITLE
Fix wrong GPIO memory offset for pins above 31

### DIFF
--- a/qemu-rpi-gpio
+++ b/qemu-rpi-gpio
@@ -78,7 +78,7 @@ class VGPIOManager(object):
     def get_gpio_location(self, num):
         if num > 54 or num < 0:
             return 0
-        return GPIO_RANGE[0] + int(num / 32)
+        return GPIO_RANGE[0] + int(num / 32) * 4
 
     def set(self, gpionum, value):
         m = self.get_gpio_location(gpionum)


### PR DESCRIPTION
Fix wrong GPIO memory offset when accessing a GPIO pin above 31.
For example, to set GPIO pin 36, the script accesses memory address
0x3f20001d instead of 0x3f200020.